### PR TITLE
continue the discussion from #2

### DIFF
--- a/svg.panzoom.js
+++ b/svg.panzoom.js
@@ -142,10 +142,22 @@ SVG.extend(SVG.Doc, SVG.Nested, {
 			.transform(new SVG.Matrix()
 					.scale(zoomAmount, point.x, point.y))
 
-		if(animate) this.animate(animate.duration, animate.easing).viewbox(b)
-		else this.viewbox(b)
+		if(animate) {
+			this.animate(animate.duration, animate.easing)
+				.viewbox(b)
+				.after(this.fire.bind(this, 'zoom'))
+		} else {
+			this.viewbox(b)
+			this.fire('zoom')
+		}
+	},
 
-		this.fire('zoom')
+	zoomToOne: function(point, animate) {
+		this.zoom(this.zoomLevel(), point, animate)
+	},
+
+	zoomLevel: function() {
+		return this.bbox().width / this.viewbox().width
 	}
 
 })

--- a/svg.panzoom.js
+++ b/svg.panzoom.js
@@ -1,164 +1,164 @@
 (function() {
 
 var normalizeEvent = function(ev) {
-	if(!ev.touches) {
-		ev.touches = [{clientX: ev.clientX, clientY: ev.clientY}]
-	}
+  if(!ev.touches) {
+    ev.touches = [{clientX: ev.clientX, clientY: ev.clientY}]
+  }
 
-	return [].slice.call(ev.touches)
+  return [].slice.call(ev.touches)
 }
 
 SVG.extend(SVG.Doc, SVG.Nested, {
 
-	panZoom: function(options) {
-		options = options || {}
-		var zoomFactor = options.zoomFactor || 0.03
+  panZoom: function(options) {
+    options = options || {}
+    var zoomFactor = options.zoomFactor || 0.03
 
-		var lastP, lastTouches, zoomInProgress = false, lastCall = +new Date()
+    var lastP, lastTouches, zoomInProgress = false, lastCall = +new Date()
 
-		var wheelZoom = function(ev) {
-			ev.preventDefault()
+    var wheelZoom = function(ev) {
+      ev.preventDefault()
 
-			var zoomAmount = ev.deltaY/Math.abs(ev.deltaY) * zoomFactor + 1
+      var zoomAmount = ev.deltaY/Math.abs(ev.deltaY) * zoomFactor + 1
 
-			var p = this.point(ev.clientX, ev.clientY)
+      var p = this.point(ev.clientX, ev.clientY)
 
-			this.zoom(zoomAmount, p)
-		}
+      this.zoom(zoomAmount, p)
+    }
 
-		var pinchZoomStart = function(ev) {
-			lastTouches = normalizeEvent(ev)
+    var pinchZoomStart = function(ev) {
+      lastTouches = normalizeEvent(ev)
 
-			if(lastTouches.length < 2 || zoomInProgress) return
-			ev.preventDefault()
+      if(lastTouches.length < 2 || zoomInProgress) return
+      ev.preventDefault()
 
-			panStop.call(this, ev)
+      panStop.call(this, ev)
 
-			zoomInProgress = true
-			SVG.on(document, 'touchmove', pinchZoom, this, {passive:false})
-			SVG.on(document, 'touchend', pinchZoomStop, this, {passive:false})
-		}
+      zoomInProgress = true
+      SVG.on(document, 'touchmove', pinchZoom, this, {passive:false})
+      SVG.on(document, 'touchend', pinchZoomStop, this, {passive:false})
+    }
 
-		var pinchZoomStop = function(ev) {
-			ev.preventDefault()
-			zoomInProgress = false
+    var pinchZoomStop = function(ev) {
+      ev.preventDefault()
+      zoomInProgress = false
 
-			SVG.off(document,'touchmove', pinchZoom)
-			SVG.off(document,'touchend', pinchZoomStop)
-			this.on('touchstart', pinchZoomStart)
+      SVG.off(document,'touchmove', pinchZoom)
+      SVG.off(document,'touchend', pinchZoomStop)
+      this.on('touchstart', pinchZoomStart)
 
-			if(ev.touches.length > 0) panStart.call(this, ev)
-		}
+      if(ev.touches.length > 0) panStart.call(this, ev)
+    }
 
-		var pinchZoom = function(ev) {
-			ev.preventDefault()
-			var currentTouches = normalizeEvent(ev)
+    var pinchZoom = function(ev) {
+      ev.preventDefault()
+      var currentTouches = normalizeEvent(ev)
 
-			var lastDelta = Math.sqrt((lastTouches[0].clientX - lastTouches[1].clientX)**2 + (lastTouches[0].clientY - lastTouches[1].clientY)**2)
-			var currentDelta = Math.sqrt((currentTouches[0].clientX - currentTouches[1].clientX)**2 + (currentTouches[0].clientY - currentTouches[1].clientY)**2)
+      var lastDelta = Math.sqrt((lastTouches[0].clientX - lastTouches[1].clientX)**2 + (lastTouches[0].clientY - lastTouches[1].clientY)**2)
+      var currentDelta = Math.sqrt((currentTouches[0].clientX - currentTouches[1].clientX)**2 + (currentTouches[0].clientY - currentTouches[1].clientY)**2)
 
-			var zoomAmount = lastDelta/currentDelta
+      var zoomAmount = lastDelta/currentDelta
 
-			var currentFocus = {
-				x: currentTouches[0].clientX + 0.5 * (currentTouches[1].clientX - currentTouches[0].clientX),
-				y: currentTouches[0].clientY + 0.5 * (currentTouches[1].clientY - currentTouches[0].clientY)
-			}
+      var currentFocus = {
+        x: currentTouches[0].clientX + 0.5 * (currentTouches[1].clientX - currentTouches[0].clientX),
+        y: currentTouches[0].clientY + 0.5 * (currentTouches[1].clientY - currentTouches[0].clientY)
+      }
 
-			var lastFocus = {
-				x: lastTouches[0].clientX + 0.5 * (lastTouches[1].clientX - lastTouches[0].clientX),
-				y: lastTouches[0].clientY + 0.5 * (lastTouches[1].clientY - lastTouches[0].clientY)
-			}
-
-
-			var p = this.point(currentFocus.x, currentFocus.y)
-			var focusP = this.point(2*currentFocus.x-lastFocus.x, 2*currentFocus.y-lastFocus.y)
-			var b = new SVG.Box(this.viewbox()).transform(
-				new SVG.Matrix()
-					.translate(p.x, p.y)
-					.scale(zoomAmount, 0, 0)
-					.translate(-focusP.x, -focusP.y)
-			)
+      var lastFocus = {
+        x: lastTouches[0].clientX + 0.5 * (lastTouches[1].clientX - lastTouches[0].clientX),
+        y: lastTouches[0].clientY + 0.5 * (lastTouches[1].clientY - lastTouches[0].clientY)
+      }
 
 
-			this.viewbox(b)
+      var p = this.point(currentFocus.x, currentFocus.y)
+      var focusP = this.point(2*currentFocus.x-lastFocus.x, 2*currentFocus.y-lastFocus.y)
+      var b = new SVG.Box(this.viewbox()).transform(
+        new SVG.Matrix()
+          .translate(p.x, p.y)
+          .scale(zoomAmount, 0, 0)
+          .translate(-focusP.x, -focusP.y)
+      )
 
-			lastTouches = currentTouches
-		}
 
-		var panStart = function(ev) {
-			ev.preventDefault()
+      this.viewbox(b)
 
-			this.off('mousedown', panStart)
-			this.off('touchstart', panStart)
+      lastTouches = currentTouches
+    }
 
-			lastTouches = normalizeEvent(ev)
+    var panStart = function(ev) {
+      ev.preventDefault()
 
-			if(zoomInProgress) return
+      this.off('mousedown', panStart)
+      this.off('touchstart', panStart)
 
-			lastP = {x: lastTouches[0].clientX, y: lastTouches[0].clientY }
+      lastTouches = normalizeEvent(ev)
 
-			SVG.on(document, 'mousemove', panning, this, {passive:false})
-			SVG.on(document, 'touchmove', panning, this, {passive:false})
-			SVG.on(document, 'mouseup', panStop, this, {passive:false})
-			SVG.on(document, 'touchend', panStop, this, {passive:false})
-		}
+      if(zoomInProgress) return
 
-		var panStop = function(ev) {
-			ev.preventDefault()
+      lastP = {x: lastTouches[0].clientX, y: lastTouches[0].clientY }
 
-			SVG.off(document,'mousemove', panning)
-			SVG.off(document,'touchmove', panning)
-			SVG.off(document,'mouseup', panStop)
-			SVG.off(document,'touchend', panStop)
-			this.on('mousedown', panStart)
-			this.on('touchstart', panStart)
-		}
+      SVG.on(document, 'mousemove', panning, this, {passive:false})
+      SVG.on(document, 'touchmove', panning, this, {passive:false})
+      SVG.on(document, 'mouseup', panStop, this, {passive:false})
+      SVG.on(document, 'touchend', panStop, this, {passive:false})
+    }
 
-		var panning = function(ev) {
-			ev.preventDefault()
-			var currentTouches = normalizeEvent(ev)
+    var panStop = function(ev) {
+      ev.preventDefault()
 
-			var currentP = {x: currentTouches[0].clientX, y: currentTouches[0].clientY }
-				, p1 = this.point(currentP.x, currentP.y)
-				, p2 = this.point(lastP.x, lastP.y)
-				, deltaP = [p2.x - p1.x, p2.y - p1.y]
-				, box = new SVG.Box(this.viewbox()).transform(new SVG.Matrix().translate(deltaP[0], deltaP[1]))
+      SVG.off(document,'mousemove', panning)
+      SVG.off(document,'touchmove', panning)
+      SVG.off(document,'mouseup', panStop)
+      SVG.off(document,'touchend', panStop)
+      this.on('mousedown', panStart)
+      this.on('touchstart', panStart)
+    }
 
-			this.viewbox(box)
-			lastP = currentP
-		}
+    var panning = function(ev) {
+      ev.preventDefault()
+      var currentTouches = normalizeEvent(ev)
 
-		this.on('wheel', wheelZoom)
-		this.on('touchstart', pinchZoomStart, this, {passive:false})
-		this.on('mousedown', panStart, this, {passive:false})
-		this.on('touchstart', panStart, this, {passive:false})
+      var currentP = {x: currentTouches[0].clientX, y: currentTouches[0].clientY }
+        , p1 = this.point(currentP.x, currentP.y)
+        , p2 = this.point(lastP.x, lastP.y)
+        , deltaP = [p2.x - p1.x, p2.y - p1.y]
+        , box = new SVG.Box(this.viewbox()).transform(new SVG.Matrix().translate(deltaP[0], deltaP[1]))
 
-		return this
+      this.viewbox(box)
+      lastP = currentP
+    }
 
-	},
+    this.on('wheel', wheelZoom)
+    this.on('touchstart', pinchZoomStart, this, {passive:false})
+    this.on('mousedown', panStart, this, {passive:false})
+    this.on('touchstart', panStart, this, {passive:false})
 
-	zoom: function(zoomAmount, point, animate) {
-		var b = new SVG.Box(this.viewbox())
-			.transform(new SVG.Matrix()
-					.scale(zoomAmount, point.x, point.y))
+    return this
 
-		if(animate) {
-			this.animate(animate.duration, animate.easing)
-				.viewbox(b)
-				.after(this.fire.bind(this, 'zoom'))
-		} else {
-			this.viewbox(b)
-			this.fire('zoom')
-		}
-	},
+  },
 
-	zoomToOne: function(point, animate) {
-		this.zoom(this.zoomLevel(), point, animate)
-	},
+  zoom: function(zoomAmount, point, animate) {
+    var b = new SVG.Box(this.viewbox())
+      .transform(new SVG.Matrix()
+          .scale(zoomAmount, point.x, point.y))
 
-	zoomLevel: function() {
-		return this.bbox().width / this.viewbox().width
-	}
+    if(animate) {
+      this.animate(animate.duration, animate.easing)
+        .viewbox(b)
+        .after(this.fire.bind(this, 'zoom'))
+    } else {
+      this.viewbox(b)
+      this.fire('zoom')
+    }
+  },
+
+  zoomToOne: function(point, animate) {
+    this.zoom(this.zoomLevel(), point, animate)
+  },
+
+  zoomLevel: function() {
+    return this.bbox().width / this.viewbox().width
+  }
 
 })
 

--- a/svg.panzoom.js
+++ b/svg.panzoom.js
@@ -1,157 +1,155 @@
 (function() {
 
 var normalizeEvent = function(ev) {
-  if(!ev.touches) {
-    ev.touches = [{clientX: ev.clientX, clientY: ev.clientY}]
-  }
+	if(!ev.touches) {
+		ev.touches = [{clientX: ev.clientX, clientY: ev.clientY}]
+	}
 
-  return [].slice.call(ev.touches)
+	return [].slice.call(ev.touches)
 }
 
 SVG.extend(SVG.Doc, SVG.Nested, {
 
-  panZoom: function(options) {
-    options = options || {}
-    var zoomFactor = options.zoomFactor || 0.03
-    var zoomAnimate = options.zoomAnimate || null
+	panZoom: function(options) {
+		options = options || {}
+		var zoomFactor = options.zoomFactor || 0.03
 
-    var lastP, lastTouches, zoomInProgress = false, lastCall = +new Date(), dirtyViewbox = this.viewbox()
+		var lastP, lastTouches, zoomInProgress = false, lastCall = +new Date()
 
-    var wheelZoom = function(ev) {
-      ev.preventDefault()
+		var wheelZoom = function(ev) {
+			ev.preventDefault()
 
-      var zoomAmount = ev.deltaY/Math.abs(ev.deltaY) * zoomFactor + 1
+			var zoomAmount = ev.deltaY/Math.abs(ev.deltaY) * zoomFactor + 1
 
-      var p = this.point(ev.clientX, ev.clientY)
+			var p = this.point(ev.clientX, ev.clientY)
 
-      zoom.call(this, zoomAmount, p, zoomAnimate)
-    }
+			this.zoom(zoomAmount, p)
+		}
 
-    var zoom = function(zoomAmount, point, animate) {
-      animate = animate || zoomAnimate
+		var pinchZoomStart = function(ev) {
+			lastTouches = normalizeEvent(ev)
 
-      var b = new SVG.Box(this.viewbox()).transform(new SVG.Matrix().scale(zoomAmount, point.x, point.y))
+			if(lastTouches.length < 2 || zoomInProgress) return
+			ev.preventDefault()
 
-      if(animate) this.animate(animate.duration, animate.easing).viewbox(b)
-      else this.viewbox(b)
+			panStop.call(this, ev)
 
-      this.fire('zoom', { zoomLevel: dirtyViewbox.height / b.height })
-    }
+			zoomInProgress = true
+			SVG.on(document, 'touchmove', pinchZoom, this, {passive:false})
+			SVG.on(document, 'touchend', pinchZoomStop, this, {passive:false})
+		}
 
-    var pinchZoomStart = function(ev) {
-      lastTouches = normalizeEvent(ev)
+		var pinchZoomStop = function(ev) {
+			ev.preventDefault()
+			zoomInProgress = false
 
-      if(lastTouches.length < 2 || zoomInProgress) return
-      ev.preventDefault()
+			SVG.off(document,'touchmove', pinchZoom)
+			SVG.off(document,'touchend', pinchZoomStop)
+			this.on('touchstart', pinchZoomStart)
 
-      panStop.call(this, ev)
+			if(ev.touches.length > 0) panStart.call(this, ev)
+		}
 
-      zoomInProgress = true
-      SVG.on(document, 'touchmove', pinchZoom, this, {passive:false})
-      SVG.on(document, 'touchend', pinchZoomStop, this, {passive:false})
-    }
+		var pinchZoom = function(ev) {
+			ev.preventDefault()
+			var currentTouches = normalizeEvent(ev)
 
-    var pinchZoomStop = function(ev) {
-      ev.preventDefault()
-      zoomInProgress = false
+			var lastDelta = Math.sqrt((lastTouches[0].clientX - lastTouches[1].clientX)**2 + (lastTouches[0].clientY - lastTouches[1].clientY)**2)
+			var currentDelta = Math.sqrt((currentTouches[0].clientX - currentTouches[1].clientX)**2 + (currentTouches[0].clientY - currentTouches[1].clientY)**2)
 
-      SVG.off(document,'touchmove', pinchZoom)
-      SVG.off(document,'touchend', pinchZoomStop)
-      this.on('touchstart', pinchZoomStart)
+			var zoomAmount = lastDelta/currentDelta
 
-      if(ev.touches.length > 0) panStart.call(this, ev)
-    }
+			var currentFocus = {
+				x: currentTouches[0].clientX + 0.5 * (currentTouches[1].clientX - currentTouches[0].clientX),
+				y: currentTouches[0].clientY + 0.5 * (currentTouches[1].clientY - currentTouches[0].clientY)
+			}
 
-    var pinchZoom = function(ev) {
-      ev.preventDefault()
-      var currentTouches = normalizeEvent(ev)
-
-      var lastDelta = Math.sqrt((lastTouches[0].clientX - lastTouches[1].clientX)**2 + (lastTouches[0].clientY - lastTouches[1].clientY)**2)
-      var currentDelta = Math.sqrt((currentTouches[0].clientX - currentTouches[1].clientX)**2 + (currentTouches[0].clientY - currentTouches[1].clientY)**2)
-
-      var zoomAmount = lastDelta/currentDelta
-
-      var currentFocus = {
-        x: currentTouches[0].clientX + 0.5 * (currentTouches[1].clientX - currentTouches[0].clientX),
-        y: currentTouches[0].clientY + 0.5 * (currentTouches[1].clientY - currentTouches[0].clientY)
-      }
-
-      var lastFocus = {
-        x: lastTouches[0].clientX + 0.5 * (lastTouches[1].clientX - lastTouches[0].clientX),
-        y: lastTouches[0].clientY + 0.5 * (lastTouches[1].clientY - lastTouches[0].clientY)
-      }
+			var lastFocus = {
+				x: lastTouches[0].clientX + 0.5 * (lastTouches[1].clientX - lastTouches[0].clientX),
+				y: lastTouches[0].clientY + 0.5 * (lastTouches[1].clientY - lastTouches[0].clientY)
+			}
 
 
-      var p = this.point(currentFocus.x, currentFocus.y)
-      var focusP = this.point(2*currentFocus.x-lastFocus.x, 2*currentFocus.y-lastFocus.y)
-      var b = new SVG.Box(this.viewbox()).transform(
-        new SVG.Matrix()
-          .translate(p.x, p.y)
-          .scale(zoomAmount, 0, 0)
-          .translate(-focusP.x, -focusP.y)
-      )
+			var p = this.point(currentFocus.x, currentFocus.y)
+			var focusP = this.point(2*currentFocus.x-lastFocus.x, 2*currentFocus.y-lastFocus.y)
+			var b = new SVG.Box(this.viewbox()).transform(
+				new SVG.Matrix()
+					.translate(p.x, p.y)
+					.scale(zoomAmount, 0, 0)
+					.translate(-focusP.x, -focusP.y)
+			)
 
 
-      this.viewbox(b)
+			this.viewbox(b)
 
-      lastTouches = currentTouches
-    }
+			lastTouches = currentTouches
+		}
 
-    var panStart = function(ev) {
-      ev.preventDefault()
+		var panStart = function(ev) {
+			ev.preventDefault()
 
-      this.off('mousedown', panStart)
-      this.off('touchstart', panStart)
+			this.off('mousedown', panStart)
+			this.off('touchstart', panStart)
 
-      lastTouches = normalizeEvent(ev)
+			lastTouches = normalizeEvent(ev)
 
-      if(zoomInProgress) return
+			if(zoomInProgress) return
 
-      lastP = {x: lastTouches[0].clientX, y: lastTouches[0].clientY }
+			lastP = {x: lastTouches[0].clientX, y: lastTouches[0].clientY }
 
-      SVG.on(document, 'mousemove', panning, this, {passive:false})
-      SVG.on(document, 'touchmove', panning, this, {passive:false})
-      SVG.on(document, 'mouseup', panStop, this, {passive:false})
-      SVG.on(document, 'touchend', panStop, this, {passive:false})
-    }
+			SVG.on(document, 'mousemove', panning, this, {passive:false})
+			SVG.on(document, 'touchmove', panning, this, {passive:false})
+			SVG.on(document, 'mouseup', panStop, this, {passive:false})
+			SVG.on(document, 'touchend', panStop, this, {passive:false})
+		}
 
-    var panStop = function(ev) {
-      ev.preventDefault()
+		var panStop = function(ev) {
+			ev.preventDefault()
 
-      SVG.off(document,'mousemove', panning)
-      SVG.off(document,'touchmove', panning)
-      SVG.off(document,'mouseup', panStop)
-      SVG.off(document,'touchend', panStop)
-      this.on('mousedown', panStart)
-      this.on('touchstart', panStart)
-    }
+			SVG.off(document,'mousemove', panning)
+			SVG.off(document,'touchmove', panning)
+			SVG.off(document,'mouseup', panStop)
+			SVG.off(document,'touchend', panStop)
+			this.on('mousedown', panStart)
+			this.on('touchstart', panStart)
+		}
 
-    var panning = function(ev) {
-      ev.preventDefault()
-      var currentTouches = normalizeEvent(ev)
+		var panning = function(ev) {
+			ev.preventDefault()
+			var currentTouches = normalizeEvent(ev)
 
-      var currentP = {x: currentTouches[0].clientX, y: currentTouches[0].clientY }
-        , p1 = this.point(currentP.x, currentP.y)
-        , p2 = this.point(lastP.x, lastP.y)
-        , deltaP = [p2.x - p1.x, p2.y - p1.y]
-        , box = new SVG.Box(this.viewbox()).transform(new SVG.Matrix().translate(deltaP[0], deltaP[1]))
+			var currentP = {x: currentTouches[0].clientX, y: currentTouches[0].clientY }
+				, p1 = this.point(currentP.x, currentP.y)
+				, p2 = this.point(lastP.x, lastP.y)
+				, deltaP = [p2.x - p1.x, p2.y - p1.y]
+				, box = new SVG.Box(this.viewbox()).transform(new SVG.Matrix().translate(deltaP[0], deltaP[1]))
 
-      this.viewbox(box)
-      lastP = currentP
-    }
+			this.viewbox(box)
+			lastP = currentP
+		}
 
-    this.on('wheel', wheelZoom)
-    this.on('touchstart', pinchZoomStart, this, {passive:false})
-    this.on('mousedown', panStart, this, {passive:false})
-    this.on('touchstart', panStart, this, {passive:false})
+		this.on('wheel', wheelZoom)
+		this.on('touchstart', pinchZoomStart, this, {passive:false})
+		this.on('mousedown', panStart, this, {passive:false})
+		this.on('touchstart', panStart, this, {passive:false})
 
-    this.zoom = zoom
+		return this
 
-    return this
+	},
 
-  }
+	zoom: function(zoomAmount, point, animate) {
+		var b = new SVG.Box(this.viewbox())
+			.transform(new SVG.Matrix()
+					.scale(zoomAmount, point.x, point.y))
+
+		if(animate) this.animate(animate.duration, animate.easing).viewbox(b)
+		else this.viewbox(b)
+
+		this.fire('zoom')
+	}
 
 })
 
 
 })()
+


### PR DESCRIPTION
Live example here: https://it-kollektivet.github.io/world/

## API

```js
.panZoom({ zoomFactor:Number }) // setup svg.panzoom.js for an element and optional define a zoomFactor (default is 0.03)
.zoom(zoomAmount, point, animate) // zoom in/out, where: zoomAmount below 1 for zooming in and above 1 to zoom out
                                  //                     point is the coordinate, in SVG user-space, to zoom from
                                  //            OPTIONAL animate is { duration, easing }
.zoomLevel() // return current zoom ratio
.zoomToOne(point, animate) // an easy way to get back to the original zoom level
```

point can be an [SVG.point](http://svgjs.com/manipulating/#point) and animate is documented here: http://svgjs.com/animating/#easing

~~You can also define a global animation via: `.panZoom({ zoomAnimate: {duration, easing} }) ` but you probably won't want that unless it's a custom function since it affects both mouse wheel zoom and programmable zoom, which can behave very different. So far I have left it as a choice for the consumer.~~

## Example

```js
var world = SVG("worldmap")
var zoomFactorOut = displayZoomLevel(document.querySelector(".info-box__zoom-factor"))

world.panZoom({ zoomFactor: 0.2 })

world.on("zoom", function() {
      zoomFactorOut(this.zoomLevel())
})

SVG.on(zoomInButton, "click", function() {
	var p = getCenterPoint(world)

	world.zoom(0.5, p, { duration: 250, easing: "<>" })
})

SVG.on(zoomOutButton, "click", function() {
	var p = getCenterPoint(world)

	world.zoom(1.5, p, { duration: 200, easing: ">" })
})

SVG.on(zoomDefaultButton, "click", function() {
      var p = getCenterPoint(world)

      world.zoomToOne(p, { duration: 400, easing: "<>" })
})

function displayZoomLevel(out) {
	return function(level) {
		out.textContent = level.toFixed(2)
	}
}

function getCenterPoint(element) {
	var size = element.node.getBoundingClientRect()
	return element.point(size.width / 2, size.height/ 2)
}
```