### PR TITLE
guard against deltaY being 0 

### DIFF
--- a/src/svg.panzoom.js
+++ b/src/svg.panzoom.js
@@ -17,6 +17,8 @@ SVG.extend(SVG.Doc, SVG.Nested, {
     var wheelZoom = function(ev) {
       ev.preventDefault()
 
+      if(ev.deltaY == 0) return
+
       var zoomAmount = this.zoom() - zoomFactor * ev.deltaY/Math.abs(ev.deltaY)
         , p = this.point(ev.clientX, ev.clientY)
 


### PR DESCRIPTION
This prevents NaN exceptions in `SVG.Matrix()` when `level` is NaN

Closing #5