### PR TITLE
[PERF] - Use native client size

### DIFF
--- a/src/svg.panzoom.js
+++ b/src/svg.panzoom.js
@@ -165,13 +165,12 @@ SVG.extend(SVG.Doc, SVG.Nested, {
   },
 
   zoom: function(level, point) {
-    var style = window.getComputedStyle(this.node)
-      , width = parseFloat(style.getPropertyValue('width'))
-      , height = parseFloat(style.getPropertyValue('height'))
+    var width = this.node.clientWidth
+      , height = this.node.clientHeight
       , v = this.viewbox()
       , zoomX = width / v.width
       , zoomY = height / v.height
-      , zoom = Math.min(zoomX, zoomY)
+      , zoom = Math.min(zoomX, zoomY);
 
     if(level == null) {
       return zoom

--- a/src/svg.panzoom.js
+++ b/src/svg.panzoom.js
@@ -170,7 +170,7 @@ SVG.extend(SVG.Doc, SVG.Nested, {
       , v = this.viewbox()
       , zoomX = width / v.width
       , zoomY = height / v.height
-      , zoom = Math.min(zoomX, zoomY);
+      , zoom = Math.min(zoomX, zoomY)
 
     if(level == null) {
       return zoom


### PR DESCRIPTION
Use clientWidth & clientHeight that seem to give much better performance on chrome when moving very large graphs