### PR TITLE
Fix function name for panZoom() in typescript type information file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,21 @@
 npm install @svgdotjs/svg.panzoom.js
 ```
 
+Include this plugin after including the svg.js library in your html document.
+
+```
+<script src="svg.js"></script>
+<script src="svg.panzoom.js"></script>
+```
+
+Or for esm just import it:
+
+```
+import '@svgdotjs/svg.panzoom.js'
+```
+
+To enable pan/zoom on an svg:
+
 ```js
 // enables panZoom
 var canvas = SVG().addTo('#id')

--- a/svg.panzoom.js.d.ts
+++ b/svg.panzoom.js.d.ts
@@ -6,6 +6,6 @@ interface options {
 
 declare module "@svgdotjs/svg.js" {
   interface Svg {
-    panzoom(options?: options): this
+    panZoom(options?: options): this
   }
 }


### PR DESCRIPTION
This commit fixes a bug in the typescript type information file (svg.panzoom.js.d.ts) where it exporting the panZoom() function incorrectly as panzoom(). Due to this calls to panZoom() from client were failing with error:

Uncaught TypeError: svg.panzoom is not a function

minor: README update to illustrate how to use this plugin from typescript.