### PR TITLE
Add `zoom` method Typescript typing

### DIFF
--- a/svg.panzoom.js.d.ts
+++ b/svg.panzoom.js.d.ts
@@ -28,5 +28,6 @@ interface options {
 declare module '@svgdotjs/svg.js' {
   interface Svg {
     panZoom(options?: options | false): this
+    zoom(lvl: number, point?: Point): this
   }
 }


### PR DESCRIPTION
I don't know how the code manages to use this function that is not present in it, I guess some magic method or something, but for Typescript we need the typing of it.

Tell me if you need something more.