### PR TITLE
fix typescript typings: rename panMouse to panButton

### DIFF
--- a/svg.panzoom.js.d.ts
+++ b/svg.panzoom.js.d.ts
@@ -17,7 +17,7 @@ interface options {
   panning?: boolean
   pinchZoom?: boolean
   wheelZoom?: boolean
-  panMouse?: MouseButton
+  panButton?: MouseButton
   oneFingerPan?: boolean
   margins?: boolean | marginOptions
   zoomFactor?: number


### PR DESCRIPTION
it has been renamed in the code a year ago in 466bcf0d185285a8ab94a8a01e20ca8a159fc78d

Best!
