### PR TITLE
fixed an issue with zoomFactor

### DIFF
--- a/src/svg.panzoom.js
+++ b/src/svg.panzoom.js
@@ -154,7 +154,7 @@ extend(Svg, {
         break
       }
 
-      let lvl = Math.pow(1 + zoomFactor, (-1 * normalizedPixelDeltaY) / 100) * this.zoom()
+      let lvl = Math.pow(zoomFactor, (-1 * normalizedPixelDeltaY) / 100) * this.zoom()
       const p = this.point(ev.clientX, ev.clientY)
 
       if (lvl > zoomMax) {


### PR DESCRIPTION
It was impossible to say "the zoom factor should be 1.1" with {zoomFactor: 1.1} as an option.
A factor is usually a multiplier.